### PR TITLE
Add node keyword in the start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/jamesknelson/webpack-black-triangle.git"
   },
   "scripts": {
-    "start": "node_modules/webpack-dev-server/bin/webpack-dev-server.js"
+    "start": "node node_modules/webpack-dev-server/bin/webpack-dev-server.js"
   },
   "keywords": [
     "webpack",


### PR DESCRIPTION
Added node in the start script because I was receiving this error (in Windows 7)
npm ERR! Failed at the webpack-black-triangle@0.1.0 start script 'node_modules/webpack-dev-server/bin/webpack-dev-server.js'.
